### PR TITLE
v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.2.0 (2025-05-06)
 
+### YANKED
+
+- **Yanked on 2025-05-06**: this release introduced a feature incompatible with Django 3.2 and 4.0. Please upgrade to ≥ 1.0.0.
+
 ### Added
 
 - Support to reordering and toggling visibility of apps and models in admin pages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v1.0.0 (2025-05-06)
+
+### Changed
+
+- Remove support for Django 3.2 and 4.0: their `get_app_list` methods lack the optional `app_label` parameter required by this package.
+- Add safeguards to prevent infinite loops in custom admin classes.
+
 ## v0.2.0 (2025-05-06)
 
 ### YANKED

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,6 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Framework :: Django :: 3.2",
-  "Framework :: Django :: 4.0",
   "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Framework :: Django :: 5.2",
 ]
 dependencies = [
-  "django>=3.2,<=5.2",
+  "django>=4.1,<=5.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-admin-flexlist"
-version = "0.2.0"
+version = "1.0.0"
 description = "A Django extension that allows users to reorder and toggle visibility of admin list view, app index, and dashboard elements"
 authors = [{ name = "rafael-frs-a" }]
 license = { file = "LICENSE" }

--- a/scripts/run_and_test.py
+++ b/scripts/run_and_test.py
@@ -145,7 +145,9 @@ def main() -> None:
         proc = runserver_and_wait()
 
         try:
-            subprocess.check_call(["pytest", "tests/", "--video=off", "--headed", "-s"])
+            subprocess.check_call(
+                ["pytest", "tests/", "--video=off", "--headed", "-s", "--slowmo", "100"]
+            )
         finally:
             kill_process_tree(proc.pid)
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,12 @@
 envlist = 
   lint,
   format,
-  py{310,311,312}-django{32,40,41,42,50,51,52}
+  py{310,311,312}-django{41,42,50,51,52}
 
 [testenv]
 allowlist_externals = playwright
 deps =
   requests
-  django32: Django>=3.2,<3.3
-  django40: Django>=4.0,<4.1
   django41: Django>=4.1,<4.2
   django42: Django>=4.2,<4.3
   django50: Django>=5.0,<5.1


### PR DESCRIPTION
### Changed

- Remove support for Django 3.2 and 4.0: their `get_app_list` methods lack the optional `app_label` parameter required by this package.
- Add safeguards to prevent infinite loops in custom admin classes.